### PR TITLE
[Feature/6] 구매자 주문 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -68,7 +68,9 @@ public class OrderController {
 
     @GetMapping
     @Operation(summary = "나의 주문 목록 조회 API", description = "나의 주문 목록을 조회하는 API 입니다. (구매자 회원용)\n\n" +
-            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다.")
+            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다."+
+            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다."
+    )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })

--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -68,7 +68,9 @@ public class OrderController {
 
     @GetMapping
     @Operation(summary = "나의 주문 목록 조회 API", description = "나의 주문 목록을 조회하는 API 입니다. (구매자 회원용)\n\n" +
-            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다.")
+            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다."+
+            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다."
+)
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })

--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -68,9 +68,7 @@ public class OrderController {
 
     @GetMapping
     @Operation(summary = "나의 주문 목록 조회 API", description = "나의 주문 목록을 조회하는 API 입니다. (구매자 회원용)\n\n" +
-            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다."+
-            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다."
-    )
+            "페이지 번호 (1 이상)과 주문 상태 필터 값을 보내주세요. 주문 상태 필터 값을 보내지 않을 경우, 전체 주문을 조회합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
구매자 주문 조회 API 구현



## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- OrderItem entity가 변경되어 ddl-auto:create로 실행 한 번 필요합니다.
- 주문 도메인과 페이징 관련 ErrorStatus가 추가되었습니다.
- 주문 관련 converter, repository, service, converter, validator가 변경되었습니다.

## ⏳ 작업 내용
- [ ]  구매자 주문 내역 조회 API 구현 (페이징 포함)
- [ ]  비회원 주문 내역 조회 API 구현 (페이징 포함)
- [ ]  특정 주문 상품의 주문 상세 내역 조회 API 구현 (구매자, 비회원 공통)
- [ ]  API Swagger 명세
- [ ]  Validation


### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
